### PR TITLE
Add CI workflow config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+      - name: Install Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22.6.0
+      - name: Install Dependencies
+        run: npm install --no-fund
+      - parallel:
+          - name: Typecheck
+            run: npm run test:types
+          - name: Lint
+            run: npm run lint
+          - name: Unit Test
+            run: npm run test:unit
+          - name: Build
+            run: npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22.6.0
+          node-version: 22.20.0
       - name: Install Dependencies
         run: npm install --no-fund
       - parallel:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "type-check": "tsc --build"
   },
   "engines": {
-    "node": ">=22.2.0"
+    "node": ">=22.12.0"
   },
   "dependencies": {
     "@devvit/start": "0.13.10",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "login": "devvit login",
     "prettier": "prettier --write .",
+    "test:types": "tsc --build",
+    "test:unit": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
     "type-check": "tsc --build"
   },
   "engines": {
@@ -31,7 +33,7 @@
     "eslint": "10.8.0",
     "globals": "17.8.0",
     "prettier": "3.9.6",
-    "typescript": "7.0.2",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.65.0",
     "vite": "8.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -6,15 +6,14 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "deploy": "npm run type-check && npm run lint && devvit upload",
+    "deploy": "npm run test:types && npm run lint && devvit upload",
     "dev": "devvit playtest",
     "launch": "npm run deploy && devvit publish",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "login": "devvit login",
     "prettier": "prettier --write .",
     "test:types": "tsc --build",
-    "test:unit": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
-    "type-check": "tsc --build"
+    "test:unit": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""
   },
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
Add .github/workflows/ci.yaml matching the bare template, and add the test:types and test:unit scripts to package.json so the workflow's typecheck, lint, unit-test, and build steps all run.

Downgrade typescript from 7.0.2 to 6.0.3 so it satisfies the typescript-eslint peer range; typescript-eslint has no released version supporting TS 7.0 yet, and the previous pin broke npm install and lint.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
